### PR TITLE
Fix: Workflows only tested old OS/Python versions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -5,14 +5,19 @@ name: Python Library Tests
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        os:
+          - ubuntu-20.04
+          - ubuntu-24.04
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,9 +7,12 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: 
           - ubuntu-20.04
+          - ubuntu-22.04
+          - ubuntu-24.04
 # Windows is broken
 #          - windows-2019
           - macOS-10.15


### PR DESCRIPTION
This updates the GitHub Actions workflows to test on Ubuntu 24.04 and Python versions 3.9 to 3.12.
